### PR TITLE
Expand the `video` element in the "screen share"-sender to the max window width available

### DIFF
--- a/compose/screen-share/receiver/src/main/resources/receiving-peer.html
+++ b/compose/screen-share/receiver/src/main/resources/receiving-peer.html
@@ -27,11 +27,14 @@
     <title>WebRTC receiver</title>
     <script src="https://unpkg.com/peerjs@1.5.4/dist/peerjs.min.js"></script>
     <style>
+        body {
+            margin: 0 auto;
+        }
+
         video {
             display: none;
             margin: 0 auto;
-            width: 50%;
-            height: 50%;
+            width: 100%;
         }
     </style>
 </head>


### PR DESCRIPTION
Previously, the `video` element in the Screen share app was using only 50% of width and height.

This changeset makes it use 100% of available width. And also, the `body` margins are removed.