### PR TITLE
Bump JxBrowser

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.23" />
+    <option name="version" value="2.0.0" />
   </component>
 </project>

--- a/compose/pomodoro/src/main/kotlin/com/teamdev/jxbrowser/examples/pomodoro/Main.kt
+++ b/compose/pomodoro/src/main/kotlin/com/teamdev/jxbrowser/examples/pomodoro/Main.kt
@@ -28,7 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.application
-import com.teamdev.jxbrowser.compose.runtime.windowExceptionHandler
+import com.teamdev.jxbrowser.view.compose.runtime.windowExceptionHandler
 
 /**
  * An entry point for Pomodoro application.

--- a/compose/pomodoro/src/main/kotlin/com/teamdev/jxbrowser/examples/pomodoro/window/PomodoroWindow.kt
+++ b/compose/pomodoro/src/main/kotlin/com/teamdev/jxbrowser/examples/pomodoro/window/PomodoroWindow.kt
@@ -43,10 +43,10 @@ import androidx.compose.ui.window.FrameWindowScope
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberWindowState
-import com.teamdev.jxbrowser.compose.BrowserView
 import com.teamdev.jxbrowser.examples.pomodoro.window.timer.RemainingTime
 import com.teamdev.jxbrowser.examples.pomodoro.window.timer.TimerControls
 import com.teamdev.jxbrowser.examples.pomodoro.window.timer.TimerPicker
+import com.teamdev.jxbrowser.view.compose.BrowserView
 
 /**
  * Creates a window with the timers and their associated WebGL animations.

--- a/compose/pomodoro/src/main/kotlin/com/teamdev/jxbrowser/examples/pomodoro/window/animation/Animator.kt
+++ b/compose/pomodoro/src/main/kotlin/com/teamdev/jxbrowser/examples/pomodoro/window/animation/Animator.kt
@@ -32,7 +32,6 @@ import com.teamdev.jxbrowser.engine.Engine
 import com.teamdev.jxbrowser.engine.RenderingMode
 import com.teamdev.jxbrowser.examples.pomodoro.window.animation.network.InterceptJarRequestCallback
 import com.teamdev.jxbrowser.frame.Frame
-import com.teamdev.jxbrowser.license.JxBrowserLicense
 import com.teamdev.jxbrowser.license.internal.LicenseProvider
 import com.teamdev.jxbrowser.net.Scheme
 import java.lang.Thread.sleep
@@ -142,11 +141,9 @@ class Animator : AutoCloseable {
  * Creates a new engine with the pre-configured [InterceptJarRequestCallback].
  */
 private fun createEngine() = Engine(RenderingMode.OFF_SCREEN) {
-    options {
-        license = LicenseProvider.license
-        schemes {
-            add(Scheme.JAR, InterceptJarRequestCallback())
-        }
+    license = LicenseProvider.license
+    schemes {
+        add(Scheme.JAR, InterceptJarRequestCallback())
     }
 }
 

--- a/compose/screen-share/receiver/src/main/kotlin/com/teamdev/jxbrowser/examples/screenshare/receiver/Main.kt
+++ b/compose/screen-share/receiver/src/main/kotlin/com/teamdev/jxbrowser/examples/screenshare/receiver/Main.kt
@@ -25,12 +25,12 @@ package com.teamdev.jxbrowser.examples.screenshare.receiver
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.window.singleWindowApplication
-import com.teamdev.jxbrowser.compose.BrowserView
 import com.teamdev.jxbrowser.dsl.Engine
 import com.teamdev.jxbrowser.engine.Engine
 import com.teamdev.jxbrowser.engine.RenderingMode.OFF_SCREEN
 import com.teamdev.jxbrowser.examples.screenshare.common.SignalingServer
 import com.teamdev.jxbrowser.license.internal.LicenseProvider
+import com.teamdev.jxbrowser.view.compose.BrowserView
 
 /**
  * A Compose application that displays the content of the shared screen.
@@ -49,9 +49,7 @@ fun main() = singleWindowApplication(title = "Screen Viewer") {
 }
 
 private fun createEngine(): Engine = Engine(OFF_SCREEN) {
-    options {
-        license = LicenseProvider.license
-    }
+    license = LicenseProvider.license
 }
 
 private val SIGNALING_SERVER = run {

--- a/compose/screen-share/sender/src/main/kotlin/com/teamdev/jxbrowser/examples/screenshare/sender/Main.kt
+++ b/compose/screen-share/sender/src/main/kotlin/com/teamdev/jxbrowser/examples/screenshare/sender/Main.kt
@@ -72,9 +72,7 @@ fun main() = singleWindowApplication(
 }
 
 private fun createEngine(): Engine = Engine(OFF_SCREEN) {
-    options {
-        license = LicenseProvider.license
-    }
+    license = LicenseProvider.license
 }
 
 private val SIGNALING_SERVER = run {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Versions of JxBrowser and the related dependencies.
-jxbrowser = "8.0.0-eap.2" # https://europe-maven.pkg.dev/jxbrowser/eaps/com/teamdev/jxbrowser/jxbrowser-mac/maven-metadata.xml
+jxbrowser = "8.0.0-eap.3" # https://europe-maven.pkg.dev/jxbrowser/eaps/com/teamdev/jxbrowser/jxbrowser-mac/maven-metadata.xml
 jxbrowser-gradlePlugin = "1.0.2" # https://github.com/TeamDev-IP/JxBrowser-Gradle-Plugin/releases
 
 # Other platforms, libraries, and plugins.

--- a/jxbrowser-license/src/main/kotlin/com/teamdev/jxbrowser/license/internal/LicenseProvider.kt
+++ b/jxbrowser-license/src/main/kotlin/com/teamdev/jxbrowser/license/internal/LicenseProvider.kt
@@ -22,7 +22,7 @@
 
 package com.teamdev.jxbrowser.license.internal
 
-import com.teamdev.jxbrowser.license.JxBrowserLicense
+import com.teamdev.jxbrowser.dsl.JxBrowserLicense
 import com.teamdev.jxbrowser.engine.EngineOptions
 import com.teamdev.jxbrowser.dsl.engine.OptionsDsl
 

--- a/web-server/pdf-export/server/src/main/kotlin/com/teamdev/jxbrowser/gallery/pdf/Browsers.kt
+++ b/web-server/pdf-export/server/src/main/kotlin/com/teamdev/jxbrowser/gallery/pdf/Browsers.kt
@@ -24,8 +24,8 @@ package com.teamdev.jxbrowser.gallery.pdf
 
 import com.teamdev.jxbrowser.browser.Browser
 import com.teamdev.jxbrowser.dsl.Engine
+import com.teamdev.jxbrowser.dsl.JxBrowserLicense
 import com.teamdev.jxbrowser.engine.RenderingMode
-import com.teamdev.jxbrowser.license.JxBrowserLicense
 import com.teamdev.jxbrowser.license.internal.LicenseProvider
 
 /**
@@ -34,9 +34,7 @@ import com.teamdev.jxbrowser.license.internal.LicenseProvider
 fun newBrowser(): Browser {
     val licenseKey = LicenseProvider.key
     val engine = Engine(RenderingMode.HARDWARE_ACCELERATED) {
-        options {
-            license = JxBrowserLicense(licenseKey)
-        }
+        license = JxBrowserLicense(licenseKey)
     }
     val browser = engine.newBrowser()
     return browser


### PR DESCRIPTION
This PR bumps JxBrowser to `8.0.0-eap.3` and fixes compatibility issues.

I've checked all apps are working (JDK 17).