### PR TITLE
Don't print headers in PDF

### DIFF
--- a/web-server/pdf-export/server/src/main/kotlin/com/teamdev/jxbrowser/gallery/pdf/PdfPrinting.kt
+++ b/web-server/pdf-export/server/src/main/kotlin/com/teamdev/jxbrowser/gallery/pdf/PdfPrinting.kt
@@ -95,6 +95,7 @@ private fun printHtmlCallback(destination: Path, onCompleted: () -> Unit): Print
             .settings()
             .pdfFilePath(destination.toAbsolutePath())
             .enablePrintingBackgrounds()
+            .disablePrintingHeaderFooter()
             .apply()
         printJob.on(PrintCompleted::class.java) { _ ->
             onCompleted()


### PR DESCRIPTION
By default, Chrome inserts header and footer into the printed PDF. They contain the current time and URL.

When our customers use PDF printing for server-side rendering, they want to hide this information. In real life, they will contain the server time and the path to a temporary page, which are irrelevant to their end users.