### PR TITLE
Use new Kotlin API extensions

### DIFF
--- a/compose/pomodoro/src/main/kotlin/com/teamdev/jxbrowser/examples/pomodoro/window/animation/network/InterceptJarRequestCallback.kt
+++ b/compose/pomodoro/src/main/kotlin/com/teamdev/jxbrowser/examples/pomodoro/window/animation/network/InterceptJarRequestCallback.kt
@@ -22,7 +22,8 @@
 
 package com.teamdev.jxbrowser.examples.pomodoro.window.animation.network
 
-import com.teamdev.jxbrowser.net.HttpHeader
+import com.teamdev.jxbrowser.dsl.net.HttpHeader
+import com.teamdev.jxbrowser.dsl.net.UrlRequestJobOptions
 import com.teamdev.jxbrowser.net.HttpStatus
 import com.teamdev.jxbrowser.net.UrlRequestJob
 import com.teamdev.jxbrowser.net.callback.InterceptUrlRequestCallback
@@ -74,11 +75,8 @@ class InterceptJarRequestCallback : InterceptUrlRequestCallback {
     }
 
     private fun overrideResponseData(entry: JarEntry, params: Params): UrlRequestJob {
-        val header = HttpHeader.of("Content-Type", entry.mimeType)
-        val options = UrlRequestJob.Options
-            .newBuilder(HttpStatus.OK)
-            .addHttpHeader(header)
-            .build()
+        val contentType = HttpHeader("Content-Type", entry.mimeType)
+        val options = UrlRequestJobOptions(HttpStatus.OK, listOf(contentType))
         val job = params.newUrlRequestJob(options).apply {
             write(entry.data)
             complete()

--- a/compose/screen-share/sender/src/main/resources/sending-peer.html
+++ b/compose/screen-share/sender/src/main/resources/sending-peer.html
@@ -70,7 +70,7 @@
             }
         }).then(stream => {
             mediaConnection = peer.call(RECEIVER_PEER_ID, stream);
-            mediaStream = stream
+            mediaStream = stream;
         });
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Versions of JxBrowser and the related dependencies.
-jxbrowser = "8.0.0-eap.6" # https://europe-maven.pkg.dev/jxbrowser/eaps/com/teamdev/jxbrowser/jxbrowser-mac/maven-metadata.xml
+jxbrowser = "8.0.0-eap.6" # https://teamdev.com/jxbrowser/release-notes/
 jxbrowser-gradlePlugin = "1.0.2" # https://github.com/TeamDev-IP/JxBrowser-Gradle-Plugin/releases
 
 # Other platforms, libraries, and plugins.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Versions of JxBrowser and the related dependencies.
-jxbrowser = "8.0.0-eap.3" # https://europe-maven.pkg.dev/jxbrowser/eaps/com/teamdev/jxbrowser/jxbrowser-mac/maven-metadata.xml
+jxbrowser = "8.0.0-eap.6" # https://europe-maven.pkg.dev/jxbrowser/eaps/com/teamdev/jxbrowser/jxbrowser-mac/maven-metadata.xml
 jxbrowser-gradlePlugin = "1.0.2" # https://github.com/TeamDev-IP/JxBrowser-Gradle-Plugin/releases
 
 # Other platforms, libraries, and plugins.


### PR DESCRIPTION
This PR makes use of new API extensions.

Also, I've changed a link from a Maven metadata file to JxBrowser releases page in a TOML file.