### PR TITLE
Make rounded corners look better and remove the scroll bar

### DIFF
--- a/compose/pomodoro/src/main/kotlin/com/teamdev/jxbrowser/examples/pomodoro/window/PomodoroWindow.kt
+++ b/compose/pomodoro/src/main/kotlin/com/teamdev/jxbrowser/examples/pomodoro/window/PomodoroWindow.kt
@@ -31,6 +31,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -139,7 +141,7 @@ private fun OutlinedContainer(content: @Composable BoxScope.() -> Unit) {
     val fillMaxSize = Modifier.fillMaxSize()
     Surface(
         modifier = fillMaxSize,
-        shape = MaterialTheme.shapes.large,
+        shape = MaterialTheme.shapes.large.copy(all = CornerSize(10.dp)),
         color = MaterialTheme.colors.background,
         border = outlinedBorder()
     ) {
@@ -159,6 +161,7 @@ private fun OutlinedCard(content: @Composable () -> Unit) {
     Card(
         elevation = 0.dp,
         border = outlinedBorder(),
+        shape = RoundedCornerShape(5.dp),
         content = content
     )
 }

--- a/compose/pomodoro/webgl/index.html
+++ b/compose/pomodoro/webgl/index.html
@@ -28,6 +28,7 @@
     <style>
         html, body {
             height: 100%;
+            overflow: hidden;
         }
         canvas {
             width: 100%;


### PR DESCRIPTION
In this pull request, we apply minor fixes to the Pomodoro tracker:

1. Adjust radii of the nested rounded corners to look neater.

   Before: 
   ![telegram-cloud-photo-size-2-5269572547891029234-m](https://github.com/user-attachments/assets/70e889f5-cae9-47ef-9064-46afd09f2333)
   After:
   ![telegram-cloud-photo-size-2-5269572547891029230-m](https://github.com/user-attachments/assets/d2cf5f49-811a-40f4-831f-dde6afc85e7c)

2. Disable scrolling in the HTML page. 

   The scrollbar near the tomato is not visible on macOS, but always appears on Windows.
   